### PR TITLE
Fix: Use published npm package over build from source

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,9 +7,9 @@ ARG REACT_APP_BACKEND_URL=http://localhost:1337
 WORKDIR /app
 
 # YARN REQUIRES GIT BINARY
-#RUN apk add git
+RUN apk add git
+RUN yarn global add typescript
 #RUN yarn global add yalc
-#RUN yarn global add typescript
 
 # INSTALL geppetto-ui as dependency
 #RUN git clone -b development https://github.com/MetaCell/geppetto-meta.git

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,31 +7,31 @@ ARG REACT_APP_BACKEND_URL=http://localhost:1337
 WORKDIR /app
 
 # YARN REQUIRES GIT BINARY
-RUN apk add git
-RUN yarn global add yalc
-RUN yarn global add typescript
+#RUN apk add git
+#RUN yarn global add yalc
+#RUN yarn global add typescript
 
 # INSTALL geppetto-ui as dependency
-RUN git clone -b development https://github.com/MetaCell/geppetto-meta.git
+#RUN git clone -b development https://github.com/MetaCell/geppetto-meta.git
 
-WORKDIR /app/geppetto-meta/geppetto.js/geppetto-ui
-RUN git pull
-RUN yarn && yarn build && yarn publish:yalc
-
-WORKDIR /app/geppetto-meta/geppetto.js/geppetto-core
-RUN yarn && yarn build && yarn publish:yalc
-
-WORKDIR /app/geppetto-meta/geppetto.js/geppetto-client
-RUN yarn && yarn build && yarn publish:yalc
+#WORKDIR /app/geppetto-meta/geppetto.js/geppetto-ui
+#RUN git pull
+#RUN yarn && yarn build && yarn publish:yalc
+#
+#WORKDIR /app/geppetto-meta/geppetto.js/geppetto-core
+#RUN yarn && yarn build && yarn publish:yalc
+#
+#WORKDIR /app/geppetto-meta/geppetto.js/geppetto-client
+#RUN yarn && yarn build && yarn publish:yalc
 
 # INSTALL PACKAGES
 WORKDIR /app/frontend
 COPY ./package.json ./
 COPY ./yarn.lock ./
 
-RUN yalc link @metacell/geppetto-ui
-RUN yalc link @metacell/geppetto-meta-client
-RUN yalc link @metacell/geppetto-meta-core
+#RUN yalc link @metacell/geppetto-ui
+#RUN yalc link @metacell/geppetto-meta-client
+#RUN yalc link @metacell/geppetto-meta-core
 RUN yarn
 
 # COPY SOURCE CODE


### PR DESCRIPTION
* geppetto-meta has issue with typescript OOM. To avoid being blocked by this the Docker image will use the npm version for now