### PR TITLE
YALE-32 UI Improvements

### DIFF
--- a/applications/neuroscan/frontend/src/components/Chart/capture-menu/highlight/GroupedResults.js
+++ b/applications/neuroscan/frontend/src/components/Chart/capture-menu/highlight/GroupedResults.js
@@ -8,11 +8,13 @@ import {
   ListItem,
   ListItemText,
   ListItemIcon, Box, Button, makeStyles,
+  Checkbox,
 } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
 import CHEVRON from '../../../../images/chevron-right.svg';
 import { ReactComponent as NeuronIcon } from '../../../../images/neuron.svg';
 import { toggleInstanceHighlight } from '../../../../redux/actions/widget';
+import vars from '../../../../styles/constants';
 
 const useStyles = makeStyles({
   button: {
@@ -21,7 +23,37 @@ const useStyles = makeStyles({
       backgroundColor: 'transparent',
     },
   },
+  selected: {
+    background: vars.selectedBgColor, // Background color when selected but not hovered
+    '& .MuiTypography-root': {
+      color: '#77478F',
+    },
+    '&:hover': {
+      background: `${vars.selectedHoverBgColor} !important`,
+      '& .MuiTypography-root': {
+        color: vars.primaryColor,
+      },
+    },
+  },
+  expanded: {
+    '&.Mui-expanded': {
+      background: vars.selectedExpandedBgColor,
+    },
+  },
 });
+
+const CustomCheckedIcon = ({ fill }) => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path
+      d="M8.25 2.56699C8.0953 2.47767 7.9047 2.47767 7.75 2.56699L3.41987 5.06699C3.26517 5.1563 3.16987 5.32137 3.16987 5.5V10.5C3.16987 10.6786 3.26517 10.8437 3.41987 10.933L7.75 13.433C7.9047 13.5223 8.0953 13.5223 8.25 13.433L12.5801 10.933C12.7348 10.8437 12.8301 10.6786 12.8301 10.5V5.5C12.8301 5.32137 12.7348 5.1563 12.5801 5.06699L8.25 2.56699Z"
+      fill={fill}
+      stroke="#4C276A"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 const GroupedResults = ({ viewerId, options }) => {
   const dispatch = useDispatch();
   const classes = useStyles();
@@ -43,9 +75,17 @@ const GroupedResults = ({ viewerId, options }) => {
           button
           key={optionName}
           onClick={() => toggleHighlight(optionName)}
+          className={isOptionSelected(optionName) ? classes.selected : ''}
         >
           <ListItemIcon>
-            <NeuronIcon style={isOptionSelected(optionName) ? { fill: '#77478F' } : {}} />
+            <Checkbox
+              edge="start"
+              checked={isOptionSelected(optionName)}
+              tabIndex={-1}
+              disableRipple
+              icon={<CustomCheckedIcon fill="none" />}
+              checkedIcon={<CustomCheckedIcon fill="#77478F" />}
+            />
           </ListItemIcon>
           <ListItemText primary={optionName} />
         </ListItem>
@@ -70,7 +110,8 @@ const GroupedResults = ({ viewerId, options }) => {
     <Box>
       <Accordion>
         <AccordionSummary
-          expandIcon={<img src={CHEVRON} width="4" height="6" alt="CHEVRON" />}
+          expandIcon={<img src={CHEVRON} width="8" height="8" alt="CHEVRON" />}
+          className={classes.expanded}
         >
           <Typography variant="h5">
             Selected
@@ -91,7 +132,9 @@ const GroupedResults = ({ viewerId, options }) => {
       </Accordion>
 
       <Accordion>
-        <AccordionSummary expandIcon={<img src={CHEVRON} width="4" height="6" alt="CHEVRON" />}>
+        <AccordionSummary
+          expandIcon={<img src={CHEVRON} width="8" height="8" alt="CHEVRON" />}
+        >
           <Typography variant="h5">
             Unselected
             <Typography variant="caption">

--- a/applications/neuroscan/frontend/src/components/Chart/capture-menu/highlight/HighlightPopover.js
+++ b/applications/neuroscan/frontend/src/components/Chart/capture-menu/highlight/HighlightPopover.js
@@ -73,6 +73,12 @@ const HighlightPopover = ({
       <Divider />
       <Box sx={{
         padding: '.5rem',
+        '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+          boxShadow: '0 0 0 0.125rem rgba(76, 39, 106, 0.15)',
+        },
+        '& .MuiOutlinedInput-root': {
+          borderRadius: '0.125rem',
+        },
       }}
       >
         <SearchBar

--- a/applications/neuroscan/frontend/src/components/Common/SearchResult.jsx
+++ b/applications/neuroscan/frontend/src/components/Common/SearchResult.jsx
@@ -16,6 +16,7 @@ import HTMLViewer from '@metacell/geppetto-meta-ui/html-viewer/HTMLViewer';
 import Checkbox from '@material-ui/core/Checkbox';
 import CHEVRON from '../../images/chevron-right.svg';
 import * as search from '../../redux/actions/search';
+import vars from '../../styles/constants';
 
 const useStyles = makeStyles(() => ({
   fade: {
@@ -29,9 +30,15 @@ const useStyles = makeStyles(() => ({
     },
     '&.selected': {
       background: '#F2EBF5', // Background color when selected but not hovered
+      '& .MuiTypography-root': {
+        color: '#77478F',
+      },
     },
     '&:hover.selected': {
       background: '#ECDFF2 !important', // Background color when both selected and hovered
+      '& .MuiTypography-root': {
+        color: vars.primaryColor,
+      },
     },
   },
 }));
@@ -115,7 +122,7 @@ const SearchResult = (props) => {
     <>
       <Accordion className={searchesCount > 0 ? classes.fade : ''} id={`${title}-result`}>
         <AccordionSummary
-          expandIcon={<img src={CHEVRON} width="4" height="6" alt="CHEVRON" />}
+          expandIcon={<img src={CHEVRON} width="8" height="8" alt="CHEVRON" />}
           IconButtonProps={{ disableRipple: true }}
         >
           <Typography variant="h5">

--- a/applications/neuroscan/frontend/src/images/chevron-right.svg
+++ b/applications/neuroscan/frontend/src/images/chevron-right.svg
@@ -1,3 +1,3 @@
-<svg width="4" height="6" viewBox="0 0 4 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M4 3L0 0V6L4 3Z" fill="black" fill-opacity="0.8"/>
 </svg>

--- a/applications/neuroscan/frontend/src/styles/constants.js
+++ b/applications/neuroscan/frontend/src/styles/constants.js
@@ -35,6 +35,9 @@ const vars = {
   downloadBgColor: 'rgba(229, 229, 229, 0.4)',
   downloadBorderColor: 'rgba(229, 229, 229, 0.3)',
   buttonConfirmationColor: '#F24822',
+  selectedBgColor: '#F2EBF5',
+  selectedHoverBgColor: '#ECDFF2',
+  selectedExpandedBgColor: '#F9F5FA',
 };
 
 export default vars;

--- a/applications/neuroscan/frontend/src/theme.js
+++ b/applications/neuroscan/frontend/src/theme.js
@@ -35,6 +35,7 @@ const {
   downloadBgColor,
   downloadBorderColor,
   buttonConfirmationColor,
+  selectedExpandedBgColor,
 } = vars;
 
 const theme = createTheme({
@@ -125,9 +126,9 @@ const theme = createTheme({
               minHeight: '2.25rem',
             },
             '& .MuiAccordionSummary-root': {
-              padding: '0 1rem',
+              padding: '0.5rem',
               '&:hover': {
-                backgroundColor: '#F9F5FA',
+                backgroundColor: selectedExpandedBgColor,
               },
             },
           },
@@ -1461,7 +1462,7 @@ const theme = createTheme({
             margin: '0.5625rem auto',
           },
           '& .MuiListItem-root': {
-            padding: '0 1rem 0 2.0625rem',
+            padding: '0 1rem 0 1.625rem',
             height: '2rem',
             '& .MuiButton-root': {
               height: '1.5rem',
@@ -1478,7 +1479,7 @@ const theme = createTheme({
             },
             '& .MuiListItemIcon-root': {
               minWidth: '0.0625rem',
-              marginRight: '0.5rem',
+              // marginRight: '0.5rem',
             },
             '& .MuiListItemText-root': {
               margin: '0',
@@ -1516,13 +1517,15 @@ const theme = createTheme({
           display: 'flex',
           alignItems: 'center',
           width: '100%',
+          fontSize: '0.75rem',
+          lineHeight: '1rem',
         },
       },
       expandIcon: {
         color: lightBlackColor,
         order: 1,
-        margin: '0 0.5rem 0 0',
-        padding: '0',
+        margin: '0 0.25rem 0 0',
+        padding: '0.25rem 0.19rem 0.25rem 0.313rem',
         '&.Mui-expanded': {
           transform: 'rotate(90deg)',
         },
@@ -1578,7 +1581,7 @@ const theme = createTheme({
             },
           },
           '& .MuiAccordionSummary-root': {
-            padding: '0 1rem',
+            padding: '0.5rem',
           },
           '& .search-bar': {
             '& + .MuiBox-root': {


### PR DESCRIPTION
Issue #YALE-32
Problem: UI Improvements
Solution: 
1. styling between highlight and search component diverge differently from what we have in the mockups (check screenshots).
 Just added box shadow for highlight modal to make it similar to search component on left sidebar.

2. X icon to remove chips does not work
It was working, didn't change anything, confirmed with Sara that is it not anymore the issue. (Sara created this issue)

3. highlight panel is not aligned with the icon
I compared styles to what is on Figma and changed it accordingly, so styles on left sidebar for list component matches what is on highlight modal window.

<img width="210" alt="image" src="https://github.com/MetaCell/geppetto-NeuroSCAN/assets/67194168/f0a85c00-6a07-4a3d-8fe6-b01ee862b27e">
<img width="195" alt="image" src="https://github.com/MetaCell/geppetto-NeuroSCAN/assets/67194168/ddd2ca3b-1367-40fa-8551-f5c5b04fbfdf">
