### PR TITLE
YALE-13 fix: Sort contacts alphabetically when no terms are passed

### DIFF
--- a/applications/neuroscan/backend/api/contact/services/contact.js
+++ b/applications/neuroscan/backend/api/contact/services/contact.js
@@ -79,6 +79,8 @@ module.exports = {
         [`%${terms[0].toLowerCase()}%`]);
 
       query = applySearchConditions(query, terms);
+    }else {
+      query.orderBy('neuronA_content.uid', 'asc');
     }
 
     query.offset(start).limit(limit);


### PR DESCRIPTION
closes https://metacell.atlassian.net/browse/YALE-33

To be fair I couldn't replicate this issue locally but from a code perspective the fix proposed looks good to me.

![image](https://github.com/MetaCell/geppetto-NeuroSCAN/assets/19196034/e719ca54-b2d6-4a96-8d38-82aae1e11319)
